### PR TITLE
(MODULES-4117) Add post-expiration recovery action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 
 
 gem 'puppet', *location_for(ENV['PUPPET_VERSION'] || 'file://../../puppet')
+gem 'chloride', "~> 0.2.2"
 
 group :test do
   gem "rspec", "~> 3.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,9 @@ GEM
       specinfra (~> 2)
     builder (3.2.2)
     byebug (9.0.6)
+    chloride (0.2.2)
+      net-scp (~> 1)
+      net-ssh (~> 2)
     coderay (1.1.1)
     deep_merge (1.1.1)
     diff-lcs (1.2.5)
@@ -293,6 +296,7 @@ DEPENDENCIES
   beaker (< 3.0)
   beaker-hostgenerator
   beaker-rspec
+  chloride (~> 0.2.2)
   pry
   pry-byebug
   pry-doc

--- a/README.markdown
+++ b/README.markdown
@@ -55,6 +55,27 @@ Check all signed certificates (including the CA certificate) for certificates th
   Expires in: 4 minutes, 19 seconds
 ~~~
 
+####puppet certregen redistribute
+
+Copy a regenerated Puppet CA certificate to all active nodes in PuppetDB in case the CA cert has already expired. This command must be run on the CA server and requires that the PostgreSQL server that PuppetDB uses is also located on the current node.
+
+~~~
+[root@pe-201640-master vagrant]# puppet certregen redistribute --username vagrant --ssh_key_file /vagrant/id_rsa
+
+{
+  "succeeded": [
+    "pe-201640-agent0.puppetdebug.vlan",
+    "pe-201640-agent1.puppetdebug.vlan",
+    "pe-201640-agent3.puppetdebug.vlan"
+    "pe-201640-agent2.puppetdebug.vlan",
+    "pe-201640-agent4.puppetdebug.vlan",
+    "pe-201640-master.puppetdebug.vlan"
+  ],
+  "failed": [
+  ]
+}
+~~~
+
 
 ###Classes
 

--- a/lib/puppet_x/certregen/ca.rb
+++ b/lib/puppet_x/certregen/ca.rb
@@ -1,3 +1,10 @@
+require 'securerandom'
+require 'shellwords'
+require 'chloride'
+
+require 'puppet'
+require 'puppet/util/execution'
+
 module PuppetX
   module Certregen
     module CA
@@ -41,6 +48,65 @@ module PuppetX
 
         PuppetX::Certregen::CA.sign(ca, Puppet::SSL::CA_NAME,
                                     {allow_dns_alt_names: false, self_signing_csr: request})
+      end
+
+      # Copy the current CA certificate to the given host.
+      #
+      # @note Only Linux systems are supported and requires that the localcacert setting on the
+      #   given host is the default path.
+      #
+      # @param [String] hostname The host to copy the CA cert to
+      # @param [Hash] config the Chloride host config
+      # @return [void]
+      def distribute_cacert(hostname, config)
+        host = Chloride::Host.new(hostname, config)
+        host.ssh_connect
+
+        Puppet.debug("SSH status for #{hostname}: #{host.ssh_status}")
+
+        log_events = lambda do |event|
+          event.data[:messages].each do |data|
+            Puppet.info "[#{data.severity}:#{data.hostname}]: #{data.message.inspect}"
+          end
+        end
+
+        src = Puppet[:cacert]
+        tmp = "cacert.pem.tmp.#{SecureRandom.uuid}"
+        dst ='/etc/puppetlabs/puppet/ssl/certs/ca.pem' # @todo: query node for localcacert
+
+        copy_action = Chloride::Action::FileCopy.new(to_host: host, from: src, to: tmp)
+        copy_action.go(&log_events)
+        if copy_action.success?
+          Puppet.info "Copied #{src} to #{hostname}:#{tmp}"
+        else
+          raise "Failed to copy #{src} to #{hostname}:#{tmp}: #{copy_action.status}"
+        end
+
+        move_action = Chloride::Action::Execute.new(host: host, cmd: "cp #{tmp} #{dst}", sudo: true)
+
+        move_action.go(&log_events)
+
+        if move_action.success?
+          Puppet.info "Updated #{hostname}:#{dst} to new CA certificate"
+        else
+          raise "Failed to copy #{tmp} to #{hostname}:#{dst}"
+        end
+      end
+
+      # Enumerate Puppet nodes without relying on PuppetDB
+      #
+      # If the Puppet CA certificate has expired we cannot rely on PuppetDB working
+      # or being able to connect to Postgres via the network. In order to access
+      # this information while the CA is in a degraded state we perform the query
+      # directly via a local psql call.
+      def certnames
+        psql = '/opt/puppetlabs/server/bin/psql -d pe-puppetdb --pset format=unaligned --pset t=on -c %s'
+        query = 'SELECT certname FROM certnames WHERE deactivated IS NULL AND expired IS NULL;'
+        cmd = psql % Shellwords.escape(query)
+        Puppet::Util::Execution.execute(cmd,
+                                        uid: 'pe-postgres',
+                                        gid: 'pe-postgres').split("\n")
+
       end
     end
   end


### PR DESCRIPTION
This commit adds a `redistribute` command that will copy via SSH a
regenerated CA certificate to all nodes listed in PuppetDB.