### PR TITLE
(MODULES-4154) Use puppet feature to test for gem

### DIFF
--- a/lib/puppet/face/certregen.rb
+++ b/lib/puppet/face/certregen.rb
@@ -1,6 +1,7 @@
 require 'puppet/face'
 require 'puppet_x/certregen/ca'
 require 'puppet_x/certregen/certificate'
+require 'puppet/feature/chloride'
 
 Puppet::Face.define(:certregen, '0.1.0') do
   copyright "Puppet", 2016
@@ -94,6 +95,10 @@ Puppet::Face.define(:certregen, '0.1.0') do
     end
 
     when_invoked do |opts|
+      unless Puppet.features.chloride?
+        raise "Unable to distribute CA certificate: the chloride gem is not available."
+      end
+
       config = {}
 
       config.merge!(username: opts[:username]) if opts[:username]

--- a/lib/puppet/feature/chloride.rb
+++ b/lib/puppet/feature/chloride.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:chloride, libs: 'chloride')

--- a/lib/puppet_x/certregen/ca.rb
+++ b/lib/puppet_x/certregen/ca.rb
@@ -1,9 +1,10 @@
 require 'securerandom'
 require 'shellwords'
-require 'chloride'
 
 require 'puppet'
 require 'puppet/util/execution'
+
+require 'puppet/feature/chloride'
 
 module PuppetX
   module Certregen


### PR DESCRIPTION
This commit removes the hard 'chloride' require in favor of using the
Puppet features functionality to detect the gem.