### PR TITLE
(maint) Fix expiry for short lived certs

### DIFF
--- a/lib/puppet_x/certregen/certificate.rb
+++ b/lib/puppet_x/certregen/certificate.rb
@@ -31,7 +31,7 @@ module PuppetX
       # @param percent [Integer]
       def expiring?(cert, percent = 10)
         remaining = cert.content.not_after - Time.now
-        lifetime = cert.content.not_after - cert.content.not_before
+        lifetime = cert.content.not_after - (cert.content.not_before + 86400)
         remaining / lifetime < (percent / 100.0)
       end
     end

--- a/spec/integration/puppet_x/certregen/certificate_spec.rb
+++ b/spec/integration/puppet_x/certregen/certificate_spec.rb
@@ -21,9 +21,19 @@ RSpec.describe PuppetX::Certregen::Certificate do
     make_certificate("expiring", not_before, not_after)
   end
 
+  let(:short_lived_certificate) do
+    not_before = Time.now - 86400
+    not_after = Time.now + (60 * 5)
+    make_certificate("expiring", not_before, not_after)
+  end
+
   describe "#expiring?" do
     it "is false for nodes outside of the expiration window" do
       expect(described_class.expiring?(ok_certificate)).to eq(false)
+    end
+
+    it "is true for newly generated short lived certificates" do
+      expect(described_class.expiring?(short_lived_certificate)).to eq(false)
     end
 
     it "is true for expired nodes" do


### PR DESCRIPTION
Certificates are generated with a not_before date of the previous day to prevent clock
skew from causing new certificates to be treated as not yet valid, so we need to remove
that time shift for the not_before date.