### PR TITLE
(MODULES-4194) update CRL lastUpdate and nextUpdate fields

### DIFF
--- a/lib/facter/has_puppet.rb
+++ b/lib/facter/has_puppet.rb
@@ -1,0 +1,10 @@
+Facter.add(:has_puppet) do
+  setcode do
+    begin
+      require 'puppet'
+      true
+    rescue LoadError
+      false
+    end
+  end
+end

--- a/lib/facter/hostcrl.rb
+++ b/lib/facter/hostcrl.rb
@@ -1,0 +1,12 @@
+Facter.add(:hostcrl) do
+  confine do
+    begin
+      require 'puppet'
+      true
+    rescue LoadError
+      false
+    end
+  end
+
+  setcode { Puppet[:hostcrl] }
+end

--- a/lib/facter/hostcrl.rb
+++ b/lib/facter/hostcrl.rb
@@ -1,12 +1,4 @@
 Facter.add(:hostcrl) do
-  confine do
-    begin
-      require 'puppet'
-      true
-    rescue LoadError
-      false
-    end
-  end
-
+  confine :has_puppet => true
   setcode { Puppet[:hostcrl] }
 end

--- a/lib/facter/localcacert.rb
+++ b/lib/facter/localcacert.rb
@@ -1,12 +1,4 @@
 Facter.add(:localcacert) do
-  confine do
-    begin
-      require 'puppet'
-      true
-    rescue LoadError
-      false
-    end
-  end
-
+  confine :has_puppet => true
   setcode { Puppet[:localcacert] }
 end

--- a/lib/puppet/face/certregen.rb
+++ b/lib/puppet/face/certregen.rb
@@ -1,6 +1,7 @@
 require 'puppet/face'
 require 'puppet_x/certregen/ca'
 require 'puppet_x/certregen/certificate'
+require 'puppet_x/certregen/crl'
 require 'puppet/feature/chloride'
 
 Puppet::Face.define(:certregen, '0.1.0') do
@@ -44,6 +45,19 @@ Puppet::Face.define(:certregen, '0.1.0') do
       PuppetX::Certregen::CA.backup
       PuppetX::Certregen::CA.regenerate(ca)
       nil
+    end
+  end
+
+  action(:crl) do
+    summary 'Update the lastUpdate and nextUpdate field for the CA CRL'
+
+    when_invoked do |opts|
+      ca = PuppetX::Certregen::CA.setup
+      PuppetX::Certregen::CRL.refresh(ca)
+    end
+
+    when_rendering(:console) do |crl|
+      "CRL next update is now #{crl.content.next_update}"
     end
   end
 

--- a/lib/puppet/functions/is_classified_with.rb
+++ b/lib/puppet/functions/is_classified_with.rb
@@ -1,0 +1,9 @@
+Puppet::Functions.create_function(:is_classified_with) do
+  dispatch :is_classified_with do
+    param 'String', :str
+  end
+
+  def is_classified_with(str)
+    closure_scope.find_global_scope.compiler.node.classes.keys.include?(str.to_s)
+  end
+end

--- a/lib/puppet/parser/functions/is_classified_with.rb
+++ b/lib/puppet/parser/functions/is_classified_with.rb
@@ -1,0 +1,4 @@
+Puppet::Parser::Functions::newfunction(:is_classified_with, :arity => 1,
+                                       :type => :rvalue) do |(str)|
+  compiler.node.classes.keys.include?(str)
+end

--- a/lib/puppet_x/certregen/crl.rb
+++ b/lib/puppet_x/certregen/crl.rb
@@ -1,0 +1,56 @@
+require 'fileutils'
+require 'openssl'
+
+module PuppetX
+  module Certregen
+    # @api private
+    # @see {Puppet::SSL::CertificateRevocationList'
+    module CRL
+      module_function
+
+      FIVE_YEARS = 5 * 365*24*60*60
+
+      def refresh(ca)
+        crl = ca.crl
+        crl_content = crl.content
+        update_to_next_crl_number(crl_content)
+        update_valid_time_range_to_start_at(crl_content, Time.now)
+        sign_with(crl_content, ca.host.key.content)
+        Puppet::SSL::CertificateRevocationList.indirection.save(crl)
+        FileUtils.cp(Puppet[:cacrl], Puppet[:hostcrl])
+        Puppet::SSL::CertificateRevocationList.indirection.find("ca")
+      end
+
+      # @api private
+      def update_valid_time_range_to_start_at(crl_content, time)
+        # The CRL is not valid if the time of checking == the time of last_update.
+        # So to have it valid right now we need to say that it was updated one second ago.
+        crl_content.last_update = time - 1
+        crl_content.next_update = time + FIVE_YEARS
+      end
+
+      # @api private
+      def update_to_next_crl_number(crl_content)
+        crl_content.extensions = with_next_crl_number_from(crl_content, crl_content.extensions)
+      end
+
+      # @api private
+      def with_next_crl_number_from(crl_content, existing_extensions)
+        existing_crl_num = existing_extensions.find { |e| e.oid == 'crlNumber' }
+        new_crl_num = existing_crl_num ? existing_crl_num.value.to_i + 1 : 0
+        extensions_without_crl_num = existing_extensions.reject { |e| e.oid == 'crlNumber' }
+        extensions_without_crl_num + [crl_number_of(new_crl_num)]
+      end
+
+      # @api private
+      def crl_number_of(number)
+        OpenSSL::X509::Extension.new('crlNumber', OpenSSL::ASN1::Integer(number))
+      end
+
+      # @api private
+      def sign_with(crl_content, cakey)
+        crl_content.sign(cakey, OpenSSL::Digest::SHA1.new)
+      end
+    end
+  end
+end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,21 +1,27 @@
 # Distribute the current Puppet CA certificate to client systems.
 #
 # To ensure the portability of this code and minimize dependencies, this class uses the `file`
-# function to distribute the CA certificate instead of having end nodes directly fetch the 
+# function to distribute the CA certificate instead of having end nodes directly fetch the
 # certificate themselves. This means that Puppet installations using a master of master/CA server
 # and compile nodes will need to run Puppet on the compile masters before the CA cert can be
 # distributed to the agents.
-class certregen::client {
-  if $settings::ca {
-    $cert = file($settings::cacert)
-  } else {
-    $cert = file($settings::localcacert)
-  }
-
-  # TODO: Windows support
+class certregen::client(
+  $manage_crl = true
+) {
   file { $localcacert:
     ensure  => present,
-    content => $cert,
+    content => file($settings::cacert, $settings::localcacert, "/dev/null"),
     mode    => '0644',
+  }
+
+  $crl_managed_by_pe = ($pe_build and versioncmp($pe_build, '3.7.0') >= 0) and is_classified_with('puppet_enterprise::profile::master')
+  $needs_crl = $manage_crl and !defined(File[$::hostcrl]) and !$crl_managed_by_pe
+
+  if $needs_crl {
+    file { $hostcrl:
+      ensure  => present,
+      content => file($settings::cacrl, $settings::hostcrl, "/dev/null"),
+      mode    => '0644',
+    }
   }
 }

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,37 +1,81 @@
 require 'spec_helper'
 
+RSpec.shared_examples "managing the CRL on the client" do |setting|
+  describe "when manage_crl is false" do
+    let(:params) {{'manage_crl' => false}}
+
+    it "doesn't manage the hostcrl on the client" do
+      should_not contain_file(client_hostcrl)
+    end
+  end
+
+  describe "when manage_crl is true" do
+    let(:params) {{'manage_crl' => true}}
+
+    it "manages the hostcrl on the client from the server '#{setting}' setting" do
+      should contain_file(client_hostcrl).with(
+        'ensure'  => 'present',
+        'content' => Puppet.settings.setting(setting).open(&:read),
+        'mode'    => '0644',
+      )
+    end
+  end
+end
+
 RSpec.describe 'certregen::client' do
   include_context "Initialize CA"
 
   let(:client_localcacert) { tmpfilename('ca.pem') }
-  let(:facts) {{ 'localcacert' => client_localcacert }}
+  let(:client_hostcrl) { tmpfilename('crl.pem') }
+
+  let(:facts) do
+    {
+      'localcacert' => client_localcacert,
+      'hostcrl'     => client_hostcrl,
+      'pe_build'    => '2016.4.0',
+    }
+  end
 
   before do
-    Puppet.settings.setting(:cacert).open('w') { |f| f.write("CA cert") }
     Puppet.settings.setting(:localcacert).open('w') { |f| f.write("local CA cert") }
+    Puppet.settings.setting(:hostcrl).open('w') { |f| f.write("local CRL") }
   end
 
-  describe 'when the compile master is the CA' do
-    before { Puppet[:ca] = true }
-
-    it do
-      should contain_file(client_localcacert).with(
-        'ensure'  => 'present',
-        'content' => Puppet.settings.setting(:cacert).open(&:read),
-        'mode'    => '0644',
-      )
+  describe 'when the compile master has CA ssl files' do
+    before do
+      Puppet.settings.setting(:cacert).open('w') { |f| f.write("CA cert") }
+      Puppet.settings.setting(:cacrl).open('w') { |f| f.write("CA CRL") }
     end
+
+    describe "managing the localcacert on the client" do
+      it do
+        should contain_file(client_localcacert).with(
+          'ensure'  => 'present',
+          'content' => Puppet.settings.setting(:cacert).open(&:read),
+          'mode'    => '0644',
+        )
+      end
+    end
+
+    it_behaves_like "managing the CRL on the client", :cacrl
   end
 
-  describe 'when the compile master is not the CA' do
-    before { Puppet[:ca] = false }
-
-    it 'manages the client CA cert from the `localcacert` setting' do
-      should contain_file(client_localcacert).with(
-        'ensure'  => 'present',
-        'content' => Puppet.settings.setting(:localcacert).open(&:read),
-        'mode'    => '0644',
-      )
+  describe "when the compile master only has agent SSL files" do
+    before do
+      FileUtils.rm(Puppet[:cacert])
+      FileUtils.rm(Puppet[:cacrl])
     end
+
+    describe "managing the localcacert on the client" do
+      it 'manages the client CA cert from the `localcacert` setting' do
+        should contain_file(client_localcacert).with(
+          'ensure'  => 'present',
+          'content' => Puppet.settings.setting(:localcacert).open(&:read),
+          'mode'    => '0644',
+        )
+      end
+    end
+
+    it_behaves_like "managing the CRL on the client", :hostcrl
   end
 end

--- a/spec/integration/puppet/face/certregen_spec.rb
+++ b/spec/integration/puppet/face/certregen_spec.rb
@@ -9,6 +9,14 @@ describe Puppet::Face[:certregen, :current] do
   include_context "Initialize CA"
 
   describe "ca action" do
+    it "invokes the cacert and crl actions" do
+      expect(described_class).to receive(:cacert).with(ca_serial: "01")
+      expect(described_class).to receive(:crl)
+      described_class.ca(ca_serial: "01")
+    end
+  end
+
+  describe "cacert action" do
     it "raises an error when the ca_serial option is not provided" do
       expect {
         described_class.ca

--- a/spec/integration/puppet_x/crl_spec.rb
+++ b/spec/integration/puppet_x/crl_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'puppet_x/certregen/crl'
+
+RSpec.describe PuppetX::Certregen::CRL do
+  include_context "Initialize CA"
+
+  describe '.refresh' do
+    def normalize_time(t)
+      t.utc.round
+    end
+
+    let(:stub_time) { normalize_time(Time.now + 60 * 60 * 24 * 365) }
+    let(:oldcrl) { @oldcrl }
+
+    before do
+      @oldcrl = Puppet::SSL::CertificateRevocationList.indirection.find("ca")
+      allow(Time).to receive(:now).and_return stub_time
+      described_class.refresh(Puppet::SSL::CertificateAuthority.new)
+    end
+
+    subject { Puppet::SSL::CertificateRevocationList.indirection.find('ca') }
+
+    it 'updates the lastUpdate field' do
+      last_update = normalize_time(subject.content.last_update.utc)
+      expect(last_update).to eq normalize_time(stub_time - 1)
+    end
+
+    it 'updates the nextUpdate field' do
+      next_update = normalize_time(subject.content.next_update.utc)
+      expect(next_update).to eq normalize_time(stub_time + described_class::FIVE_YEARS)
+    end
+
+    def crl_number(crl)
+      crl.content.extensions.find { |ext| ext.oid == 'crlNumber' }.value
+    end
+
+    it "increments the CRL number" do
+      newcrl = Puppet::SSL::CertificateRevocationList.from_instance(
+        OpenSSL::X509::CRL.new(File.read(Puppet[:cacrl])), 'ca')
+
+      old_crl_number = crl_number(oldcrl).to_i
+      new_crl_number = crl_number(newcrl).to_i
+      expect(new_crl_number).to eq old_crl_number + 1
+    end
+
+    it 'copies the cacrl to the hostcrl' do
+      cacrl = Puppet::SSL::CertificateRevocationList.from_instance(
+                               OpenSSL::X509::CRL.new(File.read(Puppet[:cacrl])), 'ca')
+      hostcrl = Puppet::SSL::CertificateRevocationList.from_instance(
+                               OpenSSL::X509::CRL.new(File.read(Puppet[:hostcrl])), 'ca')
+      expect(crl_number(cacrl)).to eq crl_number(hostcrl)
+    end
+  end
+end


### PR DESCRIPTION
/cc @nfagerlund this will need docs updates; when the CA cert is rotated the CRL should be updated as well to make sure that it doesn't expire. I'm still working on how to distribute this file.