### PR TITLE
(MODULES-4480) Add expiring soon acceptance

### DIFF
--- a/spec/acceptance/helpers.rb
+++ b/spec/acceptance/helpers.rb
@@ -1,0 +1,81 @@
+require 'openssl'
+
+# Time constants in seconds
+HOUR =  60 * 60
+DAY  =  24 * HOUR
+YEAR = 365 * DAY
+
+# Retrieve CA Certificate from the given host
+#
+# @param  [Host]           host   single Beaker::Host
+#
+# @return [OpenSSL::X509::Certificate]  Certificate object
+def get_ca_cert_on(host)
+  if host[:roles].include? 'master' then
+    ca_path = '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem'
+  else
+    ca_path = '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+  end
+  on(host, "cat #{ca_path}") do |result|
+    cert = OpenSSL::X509::Certificate.new(result.stdout)
+    return cert
+  end
+end
+
+# Execute `date` command on host with optional arguments
+# and get back a Ruby Time object
+#
+# @param [Host]            host   single Beaker::Host to run the command on
+# @param [Array<String>]   args   Array of arguments to be appended to the
+#                                 `date` command
+# @return [Time]    Ruby Time object
+def get_time_on(host, args = [])
+  arg_string = args.join(' ')
+  date = on(host, "date #{arg_string}").stdout.chomp
+  return Time.parse(date)
+end
+
+# Retrieve the CA enddate on a given host as a Ruby time object
+#
+# @param [Host]            host   single Beaker::Host to get CA enddate from
+#
+# @return [Time]    Ruby Time object, or nil if error
+def get_ca_enddate_time_on(host)
+  cert = get_ca_cert_on(host)
+  return cert.not_after if cert
+  return nil
+end
+
+# Retrieve the current ca_serial value for `puppet certgen ca` on a given host
+#
+# @param [Host]            host   single Beaker::Host to get ca_serial from
+#
+# @return [String]    ca_serial in hexadecimal, or nil if error
+def get_ca_serial_id_on(host)
+  cert = get_ca_cert_on(host)
+  return cert.serial.to_s(16) if cert
+  return nil
+end
+
+# Patch puppet to get around the date check validation.
+#
+# This method is used to patch puppet in order to prevent it from failing to
+# create a CA if the system clock is turned back in time by years. The same
+# method is used to reverse the patch with the `reverse` parameter.
+#
+# @param [Host]            host     single Beaker::Host to run the command on
+# @param [String]          reverse  causes the patch to be reversed
+def patch_puppet_date_check_on(host, reverse=nil)
+  reverse = '--reverse' if reverse
+  apply_manifest_on(host, 'package { "patch": ensure => present}')
+  interface_documentation_file = "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/interface/documentation.rb"
+  patch =<<EOF
+305c305
+<           raise ArgumentError, "copyright with a year \#{fault} is very strange; did you accidentally add or subtract two years?"
+---
+>           #raise ArgumentError, "copyright with a year \#{fault} is very strange; did you accidentally add or subtract two years?"
+EOF
+  patch_file        = host.tmpfile('iface_doc_patch')
+  create_remote_file(host, patch_file, patch)
+  on(host, "patch #{reverse} #{interface_documentation_file} < #{patch_file}", :acceptable_exit_codes => [0,1])
+end

--- a/spec/acceptance/workflow_regen_before_expire_spec.rb
+++ b/spec/acceptance/workflow_regen_before_expire_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper_acceptance'
+
+# https://forge.puppet.com/puppetlabs/certregen#refresh-a-ca-thats-expiring-soon
+describe "C99818 - workflow - regen CA before it expires" do
+  if hosts_with_role(hosts, 'master').length>0 then
+    # This workflow only works with a master to manage the CA
+    context 'setting CA to expire soon' do
+      before(:all) do
+        serial = get_ca_serial_id_on(master)
+
+        # patch puppet to defeat copywrite date check when generating historical CA
+        patch_puppet_date_check_on(master)
+
+        # determine current time on master
+        @today = get_time_on(master)
+
+        # set back the clock in order to create a CA that will be approaching its EOL
+        past = @today - (5*YEAR - 20*DAY)
+        on(master, "date #{past.strftime('%m%d%H%M%Y')}")
+        # create old CA
+        on(master, puppet(" certregen ca --ca_serial #{serial}"))
+        # update to current time
+        on(master, "date #{@today.strftime('%m%d%H%M%Y')}")
+      end
+
+      it 'should have current date' do
+        today = get_time_on(master)
+        expect(today.utc.strftime('%Y-%m-%d')).to eq @today.utc.strftime('%Y-%m-%d')
+      end
+
+      it 'should warn about pending expiration' do
+        enddate = get_ca_enddate_time_on(master)
+        on(master, puppet("certregen healthcheck")) do |result|
+          expect(result.stdout).to match(/Status:\s+expiring/)
+          expect(result.stdout).to match(/Expiration date:\s+#{enddate.utc.strftime('%Y-%m-%d')}/)
+        end
+      end
+
+      context 'restoring previously patched puppet' do
+        before(:all) do
+          # revert patch to defeat copywrite date check
+          patch_puppet_date_check_on(master, 'reverse')
+        end
+
+        context 'regenerating CA prior to expiration' do
+          before(:all) do
+            serial = get_ca_serial_id_on(master)
+            on(master, puppet("certregen ca --ca_serial #{serial}"))
+          end
+          # validate time stamp
+          it 'should update CA cert enddate' do
+            enddate = get_ca_enddate_time_on(master)
+            future = get_time_on(master, ['-d', "'5 years'"])
+            expect(future - enddate).to be <= (48*HOUR)
+          end
+
+          context 'distribute new ca to linux hosts that have been classified with `certregen::client`' do
+            before(:all) do
+              create_remote_file(master, '/etc/puppetlabs/code/environments/production/manifests/ca.pp', 'include certregen::client')
+              on(master, 'chmod 755 /etc/puppetlabs/code/environments/production/manifests/ca.pp')
+              on(master, puppet('agent -t'), :acceptable_exit_codes => [0,2])
+            end
+            it 'should update CA cert on all linux agents' do
+              master_enddate = get_ca_enddate_time_on(master)
+              agents.each do |agent|
+                on(agent, puppet('agent -t'), :acceptable_exit_codes => [0,2])
+                enddate = get_ca_enddate_time_on(agent)
+                expect(enddate).to eq master_enddate
+              end
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,7 @@
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
+require 'acceptance/helpers'
 
 run_puppet_install_helper
 install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ /pe/i


### PR DESCRIPTION
This commit adds an acceptance test for the 'expiring soon'
workflow as described in the [certregen documentation](https://github.com/puppetlabs/puppetlabs-certregen#refresh-a-ca-thats-expiring-soon)
along with helper methods to facilitate this test.