### PR TITLE
(MODULES-4681) Fix module when strict_variables is enabled

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,6 @@
 fixtures:
+  repositories:
+    "stdlib":
+      "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     "certregen": "#{source_dir}"

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -14,7 +14,8 @@ class certregen::client(
     mode    => '0644',
   }
 
-  $crl_managed_by_pe = ($::pe_build and versioncmp($::pe_build, '3.7.0') >= 0) and is_classified_with('puppet_enterprise::profile::master')
+  $pe_build = getvar('::pe_build')
+  $crl_managed_by_pe = ($pe_build and versioncmp($pe_build, '3.7.0') >= 0) and is_classified_with('puppet_enterprise::profile::master')
   $needs_crl = $manage_crl and !defined(File[$::hostcrl]) and !$crl_managed_by_pe
 
   if $needs_crl {

--- a/metadata.json
+++ b/metadata.json
@@ -9,8 +9,7 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.2 <5.0.0"
+      "name": "puppetlabs/stdlib"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,10 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-certregen",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.2.2 <5.0.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This pull makes the module work with `strict_variables` enabled in the Puppet configuration (assuming a non-PE environment).