### PR TITLE
(MODULES-4659) Uncomment check for clean STDERR

### DIFF
--- a/spec/acceptance/healthcheck_spec.rb
+++ b/spec/acceptance/healthcheck_spec.rb
@@ -12,8 +12,7 @@ describe "puppet certregen healthcheck" do
       end
       it 'should not produce a health warning' do
         on(master, "puppet certregen healthcheck") do |result|
-          # FIXME: The following check should be uncommented when MODULES-4659 is resolved.
-          #expect(result.stderr).to be_empty
+          expect(result.stderr).to be_empty
           expect(result.stdout).to match(/No certificates are approaching expiration/)
         end
       end


### PR DESCRIPTION
This commit uncomments the validation that a clean healthcheck call
should result in an empty value for STDERR.