### PR TITLE
(maint) Disable beaker tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,6 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.3.1
-    dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
-    script: bundle exec rake beaker
-    services: docker
-    sudo: required
-  - rvm: 2.3.1
-    dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
-    script: bundle exec rake beaker
-    services: docker
-    sudo: required
-  - rvm: 2.3.1
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 4.0"
   - rvm: 2.1.7


### PR DESCRIPTION
The beaker-rspec tests require PE to be installed, which can't be done
in Travis. This commit drops the failing jobs.