### PR TITLE
(maint) Disable strict dependencies check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-bla
 
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
+MetadataJsonLint.options.strict_dependencies = false
+MetadataJsonLint.options.fail_on_warnings = false
 
 desc 'Generate pooler nodesets'
 task :gen_nodeset do


### PR DESCRIPTION
Our dependency on the puppetlabs-stdlib module is very wide and we're
relying on very generic behavior, so this is one of the rare cases where
an open dependency constraint reasonable. This commit disables the
metadata.json linting check that fails on open version ranges.