### PR TITLE
Compatibility with Ruby 1.8.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,4 @@ if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end
 
-# Evaluate ~/.gemfile if it exists
-if File.exists?(File.join(Dir.home, '.gemfile'))
-  eval(File.read(File.join(Dir.home, '.gemfile')), binding)
-end
-
 # vim:ft=ruby

--- a/lib/puppet/face/certregen.rb
+++ b/lib/puppet/face/certregen.rb
@@ -26,7 +26,8 @@ Puppet::Face.define(:certregen, '0.1.0') do
       [cert, crl]
     end
 
-    when_rendering :console do |(cert, crl)|
+    when_rendering :console do |t|
+      cert, crl = t
       "CA expiration is now #{cert.content.not_after}\n" + \
       "CRL next update is now #{crl.content.next_update}"
     end
@@ -178,8 +179,8 @@ Puppet::Face.define(:certregen, '0.1.0') do
 
       config = {}
 
-      config.merge!(username: opts[:username]) if opts[:username]
-      config.merge!(ssh_key_file: File.expand_path(opts[:ssh_key_file])) if opts[:ssh_key_file]
+      config.merge!(:username => opts[:username]) if opts[:username]
+      config.merge!(:ssh_key_file => File.expand_path(opts[:ssh_key_file])) if opts[:ssh_key_file]
 
       ca = PuppetX::Certregen::CA.setup
       cacert = ca.host.certificate
@@ -188,7 +189,7 @@ Puppet::Face.define(:certregen, '0.1.0') do
         exit 1
       end
 
-      rv = {succeeded: [], failed: []}
+      rv = {:succeeded => [], :failed => []}
       PuppetX::Certregen::CA.certnames.each do |certname|
         begin
           PuppetX::Certregen::CA.distribute(certname, config)

--- a/lib/puppet/feature/chloride.rb
+++ b/lib/puppet/feature/chloride.rb
@@ -1,3 +1,3 @@
 require 'puppet/util/feature'
 
-Puppet.features.add(:chloride, libs: 'chloride')
+Puppet.features.add(:chloride, :libs => 'chloride')

--- a/lib/puppet/parser/functions/is_classified_with.rb
+++ b/lib/puppet/parser/functions/is_classified_with.rb
@@ -1,4 +1,4 @@
 Puppet::Parser::Functions::newfunction(:is_classified_with, :arity => 1,
-                                       :type => :rvalue) do |(str)|
-  compiler.node.classes.keys.include?(str)
+                                       :type => :rvalue) do |arguments|
+  compiler.node.classes.keys.include?(arguments[0])
 end

--- a/lib/puppet_x/certregen/ca.rb
+++ b/lib/puppet_x/certregen/ca.rb
@@ -41,7 +41,7 @@ module PuppetX
         request = Puppet::SSL::CertificateRequest.new(Puppet::SSL::Host::CA_NAME)
         request.generate(ca.host.key)
         PuppetX::Certregen::CA.sign(ca, Puppet::SSL::CA_NAME,
-                                    {allow_dns_alt_names: false, self_signing_csr: request})
+                                    {:allow_dns_alt_names => false, :self_signing_csr => request})
         FileUtils.cp(Puppet[:cacert], Puppet[:localcacert])
       end
 
@@ -84,7 +84,7 @@ module PuppetX
       def distribute_file(host, src, dst, blk)
         tmp = "#{File.basename(src)}.tmp.#{SecureRandom.uuid}"
 
-        copy_action = Chloride::Action::FileCopy.new(to_host: host, from: src, to: tmp)
+        copy_action = Chloride::Action::FileCopy.new(:to_host => host, :from => src, :to => tmp)
         copy_action.go(&blk)
         if copy_action.success?
           Puppet.info "Copied #{src} to #{host.hostname}:#{tmp}"
@@ -92,7 +92,7 @@ module PuppetX
           raise "Failed to copy #{src} to #{host.hostname}:#{tmp}: #{copy_action.status}"
         end
 
-        move_action = Chloride::Action::Execute.new(host: host, cmd: "cp #{tmp} #{dst}", sudo: true)
+        move_action = Chloride::Action::Execute.new(:host => host, :cmd => "cp #{tmp} #{dst}", :sudo => true)
         move_action.go(&blk)
 
         if move_action.success?
@@ -115,8 +115,8 @@ module PuppetX
         query = 'SELECT certname FROM certnames WHERE deactivated IS NULL AND expired IS NULL;'
         cmd = psql % Shellwords.escape(query)
         Puppet::Util::Execution.execute(cmd,
-                                        uid: 'pe-postgres',
-                                        gid: 'pe-postgres').split("\n")
+                                        :uid => 'pe-postgres',
+                                        :gid => 'pe-postgres').split("\n")
 
       end
 

--- a/spec/integration/puppet/face/certregen_spec.rb
+++ b/spec/integration/puppet/face/certregen_spec.rb
@@ -10,9 +10,9 @@ describe Puppet::Face[:certregen, :current] do
 
   describe "ca action" do
     it "invokes the cacert and crl actions" do
-      expect(described_class).to receive(:cacert).with(ca_serial: "01")
+      expect(described_class).to receive(:cacert).with(:ca_serial => "01")
       expect(described_class).to receive(:crl)
-      described_class.ca(ca_serial: "01")
+      described_class.ca(:ca_serial => "01")
     end
   end
 
@@ -25,19 +25,19 @@ describe Puppet::Face[:certregen, :current] do
 
     it "raises an error when the ca_serial option is not provided" do
       expect {
-        described_class.ca(ca_serial: "02")
+        described_class.ca(:ca_serial => "02")
       }.to raise_error(RuntimeError, /The serial number of the current CA certificate \(01\) does not match the serial number/)
     end
 
     it "backs up the old CA cert and regenerates a new CA cert" do
       old_cacert_serial = Puppet::SSL::CertificateAuthority.new.host.certificate.content.serial
-      described_class.ca(ca_serial: "01")
+      described_class.ca(:ca_serial => "01")
       new_cacert_serial = Puppet::SSL::CertificateAuthority.new.host.certificate.content.serial
       expect(old_cacert_serial).to_not eq(new_cacert_serial)
     end
 
     it "returns the new CA certificate" do
-      returned_cacert = described_class.ca(ca_serial: "01").first
+      returned_cacert = described_class.ca(:ca_serial => "01").first
       new_cacert = Puppet::SSL::CertificateAuthority.new.host.certificate.content
       expect(returned_cacert.content.serial).to eq new_cacert.serial
       expect(returned_cacert.content.not_after).to eq new_cacert.not_after

--- a/spec/integration/puppet_x/certregen/ca_spec.rb
+++ b/spec/integration/puppet_x/certregen/ca_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe PuppetX::Certregen::CA do
     it 'uses the positional argument form when the Puppet version predates 4.6.0' do
       stub_const('Puppet::PUPPETVERSION', '4.5.0')
       expect(ca).to receive(:sign).with('hello', false, true)
-      described_class.sign(ca, 'hello', allow_dns_alt_names: false, self_signing_csr: true)
+      described_class.sign(ca, 'hello', :allow_dns_alt_names => false, :self_signing_csr => true)
     end
 
     it 'uses the hash argument form when the Puppet version is 4.6.0 or greater' do
       stub_const('Puppet::PUPPETVERSION', '4.8.0')
-      expect(ca).to receive(:sign).with('hello', allow_dns_alt_names: false, self_signing_csr: false)
-      described_class.sign(ca, 'hello', allow_dns_alt_names: false, self_signing_csr: false)
+      expect(ca).to receive(:sign).with('hello', :allow_dns_alt_names => false, :self_signing_csr => false)
+      described_class.sign(ca, 'hello', :allow_dns_alt_names => false, :self_signing_csr => false)
     end
   end
 


### PR DESCRIPTION
In Ruby 1.8, we have to use the old way to describe hash. Moreover,
destructuring doesn't work in function signatures.

I am unable to run tests with Ruby 1.8 as newer versions of Bundle are not compatible with it anymore and older versions take forever to pull stuff from rubygems. I have tested manually the main functions (healthcheck, certificate renewal).

It would be totally OK for me to not merge this PR. If people are still using older installations of Ruby with Puppet, they should find this PR.