### PR TITLE
Add possibility to not show diff on $::hostcrl

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,7 +6,8 @@
 # and compile nodes will need to run Puppet on the compile masters before the CA cert can be
 # distributed to the agents.
 class certregen::client(
-  $manage_crl = true
+  $manage_crl = true,
+  $show_diff_crl = undef
 ) {
   file { $::localcacert:
     ensure  => present,
@@ -20,9 +21,10 @@ class certregen::client(
 
   if $needs_crl {
     file { $::hostcrl:
-      ensure  => present,
-      content => file($settings::cacrl, $settings::hostcrl, '/dev/null'),
-      mode    => '0644',
+      ensure    => present,
+      content   => file($settings::cacrl, $settings::hostcrl, '/dev/null'),
+      mode      => '0644',
+      show_diff => $show_diff_crl,
     }
   }
 }


### PR DESCRIPTION
(#MODULES-5981)  In larger environment the crl changes frequently and generates a lot of output. This PR adds the possibility to disable the diff without changing the default behaviour.