### PR TITLE
Stop showing CRL diffs

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -20,9 +20,10 @@ class certregen::client(
 
   if $needs_crl {
     file { $::hostcrl:
-      ensure  => present,
-      content => file($settings::cacrl, $settings::hostcrl, '/dev/null'),
-      mode    => '0644',
+      ensure    => present,
+      content   => file($settings::cacrl, $settings::hostcrl, '/dev/null'),
+      mode      => '0644',
+      show_diff => false,
     }
   }
 }


### PR DESCRIPTION
The CRL diff is not really useful in any way.  It's not human readable, and it's not even machine readable (the diff format drops random lines if they haven't changed).  There's not really any compelling reason to output the diff as part of the Puppet run output.